### PR TITLE
Change WeakLog4GDelegate to NSHashTable

### DIFF
--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - Log4G (0.1.0)
+  - Log4G (0.2.2)
 
 DEPENDENCIES:
   - Log4G (from `../`)
@@ -9,7 +9,7 @@ EXTERNAL SOURCES:
     :path: "../"
 
 SPEC CHECKSUMS:
-  Log4G: f03eeb05f55a8602779d8c57dce0bf32bf0e0820
+  Log4G: b534d51b2ee9a4eaff7392fa33dab4484d612012
 
 PODFILE CHECKSUM: 81a56c400e4e3d22ee496be04e2e43d21e6071c8
 


### PR DESCRIPTION
改为 `NSHashTable`，作者以前是 `Array`，如果按照原意，应该是 `NSPointerArray` 的，但是我认为 delegates 本身不应该有有序性，所以改为 `NSHashTable`。

与 `NSHashTable` 对应的是 `NSMutableSet`，本身具有不容纳 `nil` 与唯一性，所以不再进行 `filter` 与 `contain` 操作。

如果需求依然需要 `NSPointerArray`，在调用 `compact` 清除 `nil` 之前，记得先 add 一次 `nil`。

自身 Swift 弱鸡，感谢 [@DianQK](https://github.com/DianQK)。